### PR TITLE
Add config backup encryption and decryption scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ These are the relevant scripts. Bypassing ASLR is left as an exercise for the re
 
 - `decrypt.c`
 	- Allows one to decrypt `_encrypt_` strings from the config if the root password is known. Useful for decrypting the `supervisor` (default) password.
-
+- `backup_decrypt.sh`
+	- Allows to decrypt the configuration backup file if the root password is known. Useful to be able to edit the configuration exported from the web-interface.
+- `backup_encrypt.sh`
+	- Allows to encrypt a configuration json file if the root password is known. Useful to be able to restore a modified configuration through the web-interface.
 ---
 
 A combinations of vulnerabilities / design flaws used to allow for [authenticated root access](https://th0mas.nl/2020/03/26/getting-root-on-a-zyxel-vmg8825-t50-router/) in firmware `V5.50(ABPY.0)b12_20190730`:

--- a/backup_decrypt.sh
+++ b/backup_decrypt.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/sh
+IN="$1"
+OUT="$2"
+PW="ROOT_PASS_HERE"
+
+openssl enc -d -des3 -md md5 -pass pass:$PW -in "$IN" -out "$OUT"

--- a/backup_encrypt.sh
+++ b/backup_encrypt.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+IN="$1"
+OUT="$2"
+PW="ROOT_PASS_HERE"
+
+openssl enc -e -des3 -md md5 -pass pass:$PW -in "$IN" -out "$OUT"


### PR DESCRIPTION
Added simple bash scripts to wrap the encryption and decryption of the config backup if the root password is known.
Based on the following function from the zcmd binary extracted from a vmg8825-t50 with firmware V5.50(ABPY.1)b16_20210525:
![image](https://user-images.githubusercontent.com/988182/150219439-49839153-121e-4d49-990d-1dfcafa4c335.png)

I have verified that decryption works and modified encrypted configs successfully apply through the web interface restore feature.
